### PR TITLE
HiddenField doesn't play nice w/ builder patterns

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -27,10 +27,6 @@
     </module>
 
     <module name="TreeWalker">
-        <module name="HiddenField">
-            <property name="ignoreSetter" value="true" />
-            <property name="ignoreConstructorParameter" value="true" />
-        </module>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>


### PR DESCRIPTION
We could include \<property name="setterCanReturnItsClass" value="true"/\>, but not every builder method will start with "set".

I think this check is more trouble than its worth if it forces us to write unidiomatic code.